### PR TITLE
Add missing requests library install requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,9 @@ setup(
     packages=['wledpy'],
     include_package_data=True,
     platforms='any',
+    install_requires=[
+        'requests',
+    ],
     classifiers = [
         'Programming Language :: Python',
         'Natural Language :: English',


### PR DESCRIPTION
For now without version specificity

I installed your library in a new virtual environment where I did not have requests installed. Noticed the lack of this requirement then.
I did not test the installation process now after the fix. Feel free to also add a version specifier for the requirement if you want